### PR TITLE
Incorporate crc nif to calculate key hash

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,6 @@
              {preprocess, true}]}.
 
 {deps, [
-    {eredis,"1.*",
-        {git, "https://github.com/wooga/eredis.git",
-        {tag, "v1.0.8"}}}
+    {eredis,"1.*", {git, "https://github.com/wooga/eredis.git", {tag, "v1.0.8"}}},
+    {ecredis_crc16, ".*", {git, "git@github.com:HalloAppInc/ecredis-crc16.git", {branch, "master"}}}
         ]}.

--- a/src/ecredis_hasher.erl
+++ b/src/ecredis_hasher.erl
@@ -1,15 +1,18 @@
 -module(ecredis_hasher).
 
 %% API.
--export([hash/1]).
+-export([hash/1, old_hash/1]).
 
 -include("ecredis.hrl").
 
-%% TODO(vipin): Explore nif implementation. Ref: https://github.com/building39/crc16_nif
 
 %% API.
 -spec hash(string()) -> integer().
 hash(Key) ->
+    ecredis_crc16:crc16(Key) rem ?REDIS_CLUSTER_HASH_SLOTS.
+
+-spec old_hash(string()) -> integer().
+old_hash(Key) ->
     crc16(Key) rem ?REDIS_CLUSTER_HASH_SLOTS.
 
 -spec crc16(string()) -> integer().


### PR DESCRIPTION
Perf results with 3 node redis running on MacBook Pro

OLD:
1 processes took 4480128 us => 8928.316334 ops/sec
2 processes took 4681036 us => 17090.233871 ops/sec
5 processes took 5565678 us => 35934.525857 ops/sec
10 processes took 6763056 us => 59144.859957 ops/sec
20 processes took 10842144 us => 73786.144143 ops/sec
50 processes took 21486164 us => 93083.158073 ops/sec
100 processes took 39514944 us => 101227.525465 ops/sec
200 processes took 68906947 us => 116098.598883 ops/sec

NEW:
1 processes took 4082447 us => 9798.045143 ops/sec
2 processes took 4591953 us => 17421.781103 ops/sec
5 processes took 6308528 us => 31703.116797 ops/sec
10 processes took 6914373 us => 57850.509367 ops/sec
20 processes took 10190313 us => 78505.930093 ops/sec
50 processes took 17499097 us => 114291.611733 ops/sec
100 processes took 30993016 us => 129061.334334 ops/sec
200 processes took 54725925 us => 146183.001932 ops/sec