### PR TITLE
Remove this log.

### DIFF
--- a/src/ecredis.erl
+++ b/src/ecredis.erl
@@ -17,7 +17,6 @@
 
 -spec start_link({ClusterName :: atom(), InitNodes :: [{}]}) -> {ok, pid()}.
 start_link({ClusterName, InitNodes}) ->
-    error_logger:info_msg("starting ~p", [ClusterName]),
     gen_server:start_link({local, ClusterName}, ?ECREDIS_SERVER, [ClusterName, InitNodes], []).
 
 


### PR DESCRIPTION
Makes running the unit tests more clean.
In general it is unusual for libraries to log into a logger