### PR TITLE
Fix qp resend logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,37 @@
-# ecredis
-Erlang Cluster Redis Client
+# ecredis - Erlang Redis Cluster Client
 
-Based on: https://github.com/Tiroshan/eredis_cluster_client
+Resources used in the building of ecredis:
+- https://github.com/Tiroshan/eredis_cluster_client
+- https://github.com/Nordix/eredis_cluster
+
+## Creating a client
+
+TODO
+
+## Query Specs
+
+### Single Queries
+
+```erlang
+-spec q(ClusterName :: atom(), Command :: redis_command()) -> redis_result()
+```
+`q` should be used to send simple queries to Redis. 
+
+### Pipelines
+
+```erlang
+-spec qp(ClusterName :: atom(), Commands :: redis_command()) -> redis_result()
+```
+`qp` should be used for pipeline commands to Redis. It is assumed that every key in the pipeline
+hashes to the same slot. (prints out error and does not handle redirects if they don't)
+
+### Multi-Node Queries
+
+```erlang
+-spec qmn(ClusterName :: atom(), Commands :: redis_command()) -> redis_result()
+```
+`qmn` should be used to send a group of commands that don't all hash to the same slot. Internally,
+`qmn` separates the list of commands by destination (preserving order), and sends these as individual
+pipelines. Because of the nature of Redis Cluster, commands across slots are not guaranteed to happen
+in order. (commands that hash to the same slot do have this guarantee - see redis hash tags)
+

--- a/src/ecredis_logger.erl
+++ b/src/ecredis_logger.erl
@@ -8,21 +8,13 @@
 -include("ecredis.hrl").
 
 log_error(Error, Query) ->
-    error_logger:warning_msg("~p, Query type: ~p, Cluster name: ~p, Map version: ~p, Command: ~p, Slot: ~p, Pid: ~p, Response: ~p, Retries: ~p, Indices: ~p",[
-        Error,
-        Query#query.query_type,
-        Query#query.cluster_name,
-        Query#query.version,
-        Query#query.command,
-        Query#query.slot,
-        Query#query.pid,
-        Query#query.response,
-        Query#query.retries,
-        Query#query.indices
-    ]).
+    log(fun error_logger:warning_msg/2, Error, Query).
 
 log_warning(Error, Query) ->
-    error_logger:warning_msg("~p, Query type: ~p, Cluster name: ~p, Map version: ~p, Command: ~p, Slot: ~p, Pid: ~p, Response: ~p, Retries: ~p, Indices: ~p",[
+    log(fun error_logger:warning_msg/2, Error, Query).
+
+log(F, Error, Query) ->
+    erlang:apply(F, ["~p, Query type: ~p, Cluster name: ~p, Map version: ~p, Command: ~p, Slot: ~p, Pid: ~p, Response: ~p, Retries: ~p, Indices: ~p",[
         Error,
         Query#query.query_type,
         Query#query.cluster_name,
@@ -33,5 +25,5 @@ log_warning(Error, Query) ->
         Query#query.response,
         Query#query.retries,
         Query#query.indices
-    ]).
+    ]]).
 


### PR DESCRIPTION
- Don't resend qp when the don't all hash to the same slot
  - Alter test cases to use qmn instead of qp to reflect this change
- Resend failed commands as a pipeline when they have the same destination
  - More efficient implementation : 1 round trip vs O(n) round trips when a qp pipeline fails
  - More robust implementation: fixes corner case that could cause pipelined commands to be executed out of order
- Fix bug in query_by_slot that would cause query to be sent twice if pid lookup fails initially
