### PR TITLE
Add error handling to qn, add tests

### DIFF
--- a/include/ecredis.hrl
+++ b/include/ecredis.hrl
@@ -34,6 +34,7 @@
     command :: redis_command(), % the command to send
     slot :: integer(), % the slot of the command
     pid :: pid(), % pid of the node to send query to
+    node :: #node{}, % the IP and Port of the node to query, only used in qn
     response :: redis_result(), % response from redis
     retries :: integer(), % number of retries for a given query
     indices :: [integer()] % indices of commands, used to merge retried 


### PR DESCRIPTION
Added some unit tests - for flushdb, qn and qa functions. 

Added error handling in qn that selectively retries. The point of qn is to query a specific node, so we do not retry on MOVED and ASK errors.