### PR TITLE
fix wrong cluster error in query

### DIFF
--- a/test/ecredis_test_util.erl
+++ b/test/ecredis_test_util.erl
@@ -192,8 +192,5 @@ ensure_redis_installed() ->
 
 cleanup_files() ->
     os:cmd("cd ../scripts; ./create-cluster clean"),
-%%    % cleanup any old files for this node.
-%%    os:cmd(lists:flatten(io_lib:format(
-%%        "rm nodes-~p.conf appendonly-~p.aof dump-~p.rdb ~p.log", [Port, Port, Port, Port]))),
     ok.
 

--- a/test/ecredis_tests.erl
+++ b/test/ecredis_tests.erl
@@ -51,7 +51,8 @@ all_test_() ->
             fun specific_node_a/0,
             fun qmn_maintains_ordering_a/0,
             fun init_tests:start_and_stop/0,
-            fun init_tests:stop_by_pid/0
+            fun init_tests:stop_by_pid/0,
+            fun init_tests:wrong_cluster_name/0
             ]}}.
 
 

--- a/test/init_tests.erl
+++ b/test/init_tests.erl
@@ -11,7 +11,8 @@
 
 -export([
     start_and_stop/0,
-    stop_by_pid/0
+    stop_by_pid/0,
+    wrong_cluster_name/0
 ]).
 
 -include_lib("eunit/include/eunit.hrl").
@@ -46,5 +47,9 @@ stop_by_pid() ->
     ?assertEqual(true, is_process_alive(Pid)),
     ok = ecredis:stop(Pid),
     ?assertEqual(false, is_process_alive(Pid)),
+    ok.
+
+wrong_cluster_name() ->
+    ?assertError({ecredis_invalid_client, foo}, ecredis:q(foo, ["GET", "foo"])),
     ok.
 


### PR DESCRIPTION
Before this change if you mistype the cluster name you get very generric
badarg error on the ets:lookup. No users of the ecredis client will get
more descriptive error.

Also few small cleanups