### PR TITLE
fix qp asking

### DIFF
--- a/src/ecredis.erl
+++ b/src/ecredis.erl
@@ -441,7 +441,6 @@ handle_ask(#query{command = Command, retries = Retries,
         {ok, Slot, Pid, Version} ->
             Command2 = case CommandType of
                 multi -> [["ASKING"] | Command];
-                % TODO: likely this is wrong for qp commands also. Add tests for qmn and asking
                 _ -> [["ASKING"], Command]
             end,
             ?WARNING("Command (~p) ~p -> ~p", [Query#query.command_type, Command, Command2]),

--- a/src/ecredis.erl
+++ b/src/ecredis.erl
@@ -286,6 +286,7 @@ execute_query(#query{command = Command, retries = Retries, pid = Pid} = Query) -
             case check_sanity_of_keys(NewQuery) of
                 ok ->
                     % Reexecute all queries that failed
+                    [ecredis_logger:log_error("Retrying query: ", Q) || Q <- QueriesToResend],
                     NewSuccesses = [execute_query(Q) || Q <- QueriesToResend],
                     % Put the original successes and new successes back in order.
                     % The merging logic is primarily intended for qmn, as qp redirects

--- a/test/moved_tests.erl
+++ b/test/moved_tests.erl
@@ -75,6 +75,7 @@ expand_cluster() ->
     [[[_Host, DestPort]]] = ecredis_server:lookup_address_info(ecredis_test, Pid2),
     ?assertEqual(30057, DestPort),
 
+
     ok = ecredis_test_util:migrate_slot(Slot, 30057, Port),
 
     ok = ecredis_test_util:remove_node(30058),


### PR DESCRIPTION
If we do qp query and some of our queries receive asking replies we were
not handling this properly. One issue is that when a command fails with
ASK error, you have to generate 2 commands [["ASKING"],
OriginalCommand],

This is a problem when we try to merge the error messages and re-execute
the commands since some things might return a single command and some
places might return this list of commands.