### PR TITLE
Fix executing commands related to memory usage

### DIFF
--- a/src/ecredis_command_parser.erl
+++ b/src/ecredis_command_parser.erl
@@ -144,9 +144,9 @@ check_sanity_of_keys([Term1, _Term2 | Rest]) ->
         "memory" ->
             %% duplicate logic similar to get_key_from_command.
             case Rest of
-                [Term3 | _] when is_binary(Term3) -> binary_to_list(Term3);
-                [Term3 | _] when is_list(Term3) -> Term3;
-                _ -> undefined
+                [Term3 | _] when is_binary(Term3) -> [binary_to_list(Term3)];
+                [Term3 | _] when is_list(Term3) -> [Term3];
+                _ -> [undefined]
             end;
         _ ->
             [undefined]
@@ -165,7 +165,7 @@ get_keys_from_rest([NumKeys | Rest]) when is_integer(NumKeys) ->
             end
         end, Keys);
 get_keys_from_rest(_) ->
-    undefined.
+    [undefined].
 
 
 -spec validate_keys([any()]) -> ok | error.

--- a/src/ecredis_command_parser.erl
+++ b/src/ecredis_command_parser.erl
@@ -57,6 +57,12 @@ get_key_from_command([Term1, Term2|Rest]) ->
             undefined;
         "evalsha" ->
             get_key_from_rest(Rest);
+        "memory" ->
+            case Rest of
+                [Term3 | _] when is_binary(Term3) -> binary_to_list(Term3);
+                [Term3 | _] when is_list(Term3) -> Term3;
+                _ -> undefined
+            end;
         _ ->
             Term2
     end;
@@ -135,6 +141,13 @@ check_sanity_of_keys([Term1, _Term2 | Rest]) ->
             get_keys_from_rest(Rest);
         "evalsha" ->
             get_keys_from_rest(Rest);
+        "memory" ->
+            %% duplicate logic similar to get_key_from_command.
+            case Rest of
+                [Term3 | _] when is_binary(Term3) -> binary_to_list(Term3);
+                [Term3 | _] when is_list(Term3) -> Term3;
+                _ -> undefined
+            end;
         _ ->
             [undefined]
     end,

--- a/test/command_sanity_test.erl
+++ b/test/command_sanity_test.erl
@@ -56,3 +56,18 @@ eval_command2_test() ->
     ok.
 
 
+memory_command_test() ->
+    Command1 = [
+        ["MEMORY", "USAGE", <<"abc:{1}">>],
+        ["MEMORY", "USAGE", <<"def:{1}">>]
+    ],
+    ?assertEqual(ok, ecredis_command_parser:check_sanity_of_keys(Command1)),
+
+    Command2 = [
+        ["MEMORY", "USAGE", <<"abc:{1}">>],
+        ["MEMORY", "USAGE", <<"def:{2}">>]
+    ],
+    ?assertEqual(error, ecredis_command_parser:check_sanity_of_keys(Command2)),
+    ok.
+
+


### PR DESCRIPTION
- command: ["memory", "usage", key .....] - was not really working.
- this is because the key was always being picked to be usage - so it never maps to the correct cluster at-times.
- this diff fixes it for all these commands.
- added a unit test.