### PR TITLE
Add macros to unblock Dialyzer

### DIFF
--- a/include/logger.hrl
+++ b/include/logger.hrl
@@ -27,3 +27,11 @@
 
 -define(ERROR(Format, Args),
     begin lager:error([{fmt, Format}, {args, Args}], Format, Args), ok end).
+
+
+-define(CRITICAL(Format),
+    begin lager:critical(Format, []), ok end).
+
+-define(CRITICAL(Format, Args),
+    begin lager:critical([{fmt, Format}, {args, Args}], Format, Args), ok end).
+


### PR DESCRIPTION
Currently one of the reasons dialyzer won't run on our codebase is because this library doesn't have a `?CRITICAL` macro in `logger.hrl`. This just adds that macro using the definition from the ejabberd logger file. 